### PR TITLE
test(auth): add table-driven unit tests for GetAPIKey

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -7,6 +7,7 @@ import (
 )
 
 var ErrNoAuthHeaderIncluded = errors.New("no authorization header included")
+var ErrMalformedAuthHeader = errors.New("malformed authorization header")
 
 // GetAPIKey -
 func GetAPIKey(headers http.Header) (string, error) {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+var errMalformedAuthHeader = errors.New("malformed authorization header") // promote this to match by type
+
+func TestGetAPIKey(t *testing.T) {
+	tests := map[string]struct {
+		authHeader    string
+		expectedKey   string
+		expectedError error
+	}{
+		"valid header": {
+			authHeader:    "ApiKey abc123",
+			expectedKey:   "abc123",
+			expectedError: nil,
+		},
+		"missing header": {
+			authHeader:    "",
+			expectedKey:   "",
+			expectedError: ErrNoAuthHeaderIncluded,
+		},
+		"malformed header (wrong scheme)": {
+			authHeader:    "Bearer abc123",
+			expectedKey:   "",
+			expectedError: errMalformedAuthHeader,
+		},
+		"malformed header (missing key)": {
+			authHeader:    "ApiKey",
+			expectedKey:   "",
+			expectedError: errMalformedAuthHeader,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			headers := http.Header{}
+			if tc.authHeader != "" {
+				headers.Set("Authorization", tc.authHeader)
+			}
+
+			key, err := GetAPIKey(headers)
+
+			if key != tc.expectedKey {
+				t.Errorf("expected key '%s', got '%s'", tc.expectedKey, key)
+			}
+
+			switch {
+			case err != nil && tc.expectedError != nil && err.Error() != tc.expectedError.Error():
+				t.Errorf("expected error '%v', got '%v'", tc.expectedError, err)
+			case err == nil && tc.expectedError != nil:
+				t.Errorf("expected error '%v', got nil", tc.expectedError)
+			case err != nil && tc.expectedError == nil:
+				t.Errorf("expected no error, got '%v'", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds table-driven unit tests for GetAPIKey in the auth package. Covers valid, missing, and malformed headers.
