### PR TITLE
update ci.yml to run tests and intentionally break auth.go for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,5 @@ jobs:
         with:
           go-version: "1.23.0"
 
-      - name: Check Go version
-        run: go version
+      - name: Run tests
+        run: go test ./...

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -15,7 +15,7 @@ func GetAPIKey(headers http.Header) (string, error) {
 	if authHeader == "" {
 		return "", ErrNoAuthHeaderIncluded
 	}
-	splitAuth := strings.Split(authHeader, " ")
+	splitAuth := strings.Split(authHeader, "/")
 	if len(splitAuth) < 2 || splitAuth[0] != "ApiKey" {
 		return "", errors.New("malformed authorization header")
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -15,7 +15,7 @@ func GetAPIKey(headers http.Header) (string, error) {
 	if authHeader == "" {
 		return "", ErrNoAuthHeaderIncluded
 	}
-	splitAuth := strings.Split(authHeader, "/")
+	splitAuth := strings.Split(authHeader, " ")
 	if len(splitAuth) < 2 || splitAuth[0] != "ApiKey" {
 		return "", errors.New("malformed authorization header")
 	}


### PR DESCRIPTION
Update ci.yml to run tests.
Set split in GetAPIKey to "/" for testing purposes. This workflow should now fail.